### PR TITLE
feat: Include release folder in Git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@
 .externalNativeBuild
 .cxx
 local.properties
-/release


### PR DESCRIPTION
The 'release' folder was previously excluded from Git tracking via the .gitignore file. This commit removes the '/release' entry from .gitignore to ensure the contents of the release folder are now tracked by Git, as per user request.