### PR TITLE
docs: add privacy policy page (fix Play Store 404)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -500,6 +500,7 @@ Material 3 + MVVM</code>
   <footer>
     <div class="container">
       <p>Calendar App is built to be fast, private, and focused on the daily rhythm of Persian and Gregorian dates.</p>
+      <p><a href="./privacy.html">Privacy Policy</a></p>
     </div>
   </footer>
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy | Persian Pro Calendar</title>
+  <meta name="description" content="Privacy policy for Persian Pro Calendar (com.cocode.calendar): the app collects no personal data and stores everything on your device." />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://cocodedk.github.io/persian-calendar/privacy.html" />
+  <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,800&family=Sora:wght@300;400;600;700&family=Vazirmatn:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #e8f4ef; --bg-2: #d7eee5; --ink: #0b2d25; --muted: #55706a;
+      --primary: #019a64; --primary-2: #025842; --accent: #43c7f9;
+      --card: #ffffff; --shadow: 0 20px 60px rgba(2, 88, 66, 0.2); --radius: 18px;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; font-family: "Sora", system-ui, -apple-system, "Segoe UI", sans-serif;
+      color: var(--ink); line-height: 1.65;
+      background: radial-gradient(1200px 700px at 20% -10%, #ffffff 0%, var(--bg) 55%, var(--bg-2) 100%);
+    }
+    a { color: var(--primary-2); }
+    .container { width: min(760px, 92vw); margin: 0 auto; padding: 48px 0 64px; }
+    .back { display: inline-block; margin-bottom: 22px; color: var(--muted); text-decoration: none; font-size: 0.92rem; }
+    .back:hover { color: var(--primary-2); }
+    .card {
+      background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow);
+      padding: clamp(24px, 5vw, 44px);
+    }
+    h1 { font-family: "Fraunces", Georgia, serif; font-weight: 800; font-size: clamp(1.9rem, 5vw, 2.6rem); margin: 0 0 6px; color: var(--primary-2); }
+    h2 { font-family: "Fraunces", Georgia, serif; font-weight: 600; font-size: 1.25rem; margin: 30px 0 8px; color: var(--ink); }
+    .meta { color: var(--muted); font-size: 0.9rem; margin: 0 0 8px; }
+    p, li { color: #1c3a33; }
+    ul { padding-inline-start: 1.2em; }
+    li { margin: 4px 0; }
+    strong { color: var(--primary-2); }
+    .divider { height: 1px; background: linear-gradient(90deg, transparent, rgba(2,88,66,0.2), transparent); margin: 44px 0; }
+    section[dir="rtl"] { font-family: "Vazirmatn", "Sora", system-ui, sans-serif; text-align: right; }
+    section[dir="rtl"] h1, section[dir="rtl"] h2 { font-family: "Vazirmatn", "Fraunces", serif; }
+    footer { color: var(--muted); font-size: 0.85rem; margin-top: 40px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a class="back" href="./index.html">&larr; Persian Pro Calendar</a>
+    <div class="card">
+
+      <!-- ==================== ENGLISH ==================== -->
+      <section lang="en">
+        <h1>Privacy Policy</h1>
+        <p class="meta">Persian Pro Calendar &middot; <code>com.cocode.calendar</code></p>
+        <p class="meta">Last updated: 14 July 2026</p>
+
+        <p><strong>Persian Pro Calendar does not collect, transmit, or share any personal data.</strong>
+        The app is a Gregorian and Persian (Jalali) calendar that works entirely on your device.</p>
+
+        <h2>Data you create</h2>
+        <p>Any calendar events you add — their title, description, dates, and colour — are stored only in a
+        private database on your own device. This information is never sent to us or to any third party.
+        It stays on your phone and is removed if you delete the app or clear its data.</p>
+
+        <h2>No internet, no tracking</h2>
+        <ul>
+          <li>The app requests <strong>no internet permission</strong>, so it is technically unable to send your data anywhere.</li>
+          <li>We use <strong>no analytics, no crash reporting, and no advertising</strong>.</li>
+          <li>There are <strong>no third-party SDKs, no cookies, and no advertising identifiers</strong>.</li>
+          <li>The app requests <strong>no runtime permissions</strong> (no location, contacts, camera, or storage access).</li>
+        </ul>
+
+        <h2>Device backup</h2>
+        <p>If you have enabled Android Auto Backup or Google account backup on your device, the operating system
+        may include this app's local data in your own personal Google backup. This is controlled entirely by you
+        and Google — we have no access to it. See
+        <a href="https://policies.google.com/privacy" rel="noopener" target="_blank">Google's Privacy Policy</a> for details.</p>
+
+        <h2>External links</h2>
+        <p>The app contains links to the developer's website (<a href="https://cocode.dk" rel="noopener" target="_blank">cocode.dk</a>)
+        and LinkedIn profile. Selecting them opens your browser; those sites are governed by their own privacy policies.</p>
+
+        <h2>Children</h2>
+        <p>The app does not knowingly collect data from anyone, including children.</p>
+
+        <h2>Changes</h2>
+        <p>If this policy changes, the updated version will be posted on this page with a new "last updated" date.</p>
+
+        <h2>Contact</h2>
+        <p>Questions about this policy can be sent to
+        <a href="mailto:bb@cocode.dk">bb@cocode.dk</a> (CoCode.dk, developer: Babak Bandpey).</p>
+      </section>
+
+      <div class="divider"></div>
+
+      <!-- ==================== PERSIAN (فارسی) ==================== -->
+      <section lang="fa" dir="rtl">
+        <h1>سیاست حفظ حریم خصوصی</h1>
+        <p class="meta">تقویم پرشین پرو &middot; <code>com.cocode.calendar</code></p>
+        <p class="meta">آخرین به‌روزرسانی: ۱۴ ژوئیه ۲۰۲۶</p>
+
+        <p><strong>تقویم پرشین پرو هیچ داده شخصی‌ای را جمع‌آوری، ارسال یا با دیگران به اشتراک نمی‌گذارد.</strong>
+        این برنامه یک تقویم میلادی و شمسی (جلالی) است که به‌طور کامل روی دستگاه شما کار می‌کند.</p>
+
+        <h2>داده‌هایی که شما می‌سازید</h2>
+        <p>هر رویدادی که به تقویم اضافه می‌کنید — عنوان، توضیح، تاریخ‌ها و رنگ آن — تنها در یک پایگاه‌دادهٔ خصوصی
+        روی دستگاه خودتان ذخیره می‌شود. این اطلاعات هرگز برای ما یا هیچ شخص ثالثی ارسال نمی‌شود، روی گوشی شما
+        باقی می‌ماند و با حذف برنامه یا پاک‌کردن داده‌های آن، از بین می‌رود.</p>
+
+        <h2>بدون اینترنت، بدون ردیابی</h2>
+        <ul>
+          <li>برنامه <strong>هیچ دسترسی اینترنتی</strong> درخواست نمی‌کند، بنابراین از نظر فنی قادر به ارسال داده‌های شما به هیچ‌جا نیست.</li>
+          <li>ما از <strong>هیچ ابزار تحلیلی، گزارش خطا یا تبلیغاتی</strong> استفاده نمی‌کنیم.</li>
+          <li>هیچ <strong>کیت توسعهٔ شخص ثالث، کوکی یا شناسهٔ تبلیغاتی</strong> وجود ندارد.</li>
+          <li>برنامه <strong>هیچ مجوز زمان‌اجرایی</strong> (موقعیت مکانی، مخاطبین، دوربین یا حافظه) درخواست نمی‌کند.</li>
+        </ul>
+
+        <h2>پشتیبان‌گیری دستگاه</h2>
+        <p>اگر پشتیبان‌گیری خودکار اندروید یا پشتیبان‌گیری حساب گوگل را فعال کرده باشید، سیستم‌عامل ممکن است
+        داده‌های محلی این برنامه را در پشتیبان شخصی گوگل شما بگنجاند. این کار کاملاً توسط شما و گوگل کنترل می‌شود
+        و ما به آن دسترسی نداریم. برای جزئیات به
+        <a href="https://policies.google.com/privacy" rel="noopener" target="_blank">سیاست حریم خصوصی گوگل</a> مراجعه کنید.</p>
+
+        <h2>پیوندهای بیرونی</h2>
+        <p>برنامه شامل پیوندهایی به وب‌سایت توسعه‌دهنده (<a href="https://cocode.dk" rel="noopener" target="_blank">cocode.dk</a>)
+        و پروفایل لینکدین است. انتخاب آن‌ها مرورگر شما را باز می‌کند و این سایت‌ها تابع سیاست‌های حریم خصوصی خودشان هستند.</p>
+
+        <h2>کودکان</h2>
+        <p>این برنامه آگاهانه هیچ داده‌ای را از هیچ‌کس، از جمله کودکان، جمع‌آوری نمی‌کند.</p>
+
+        <h2>تغییرات</h2>
+        <p>در صورت تغییر این سیاست، نسخهٔ به‌روزشده با تاریخ جدید در همین صفحه منتشر خواهد شد.</p>
+
+        <h2>تماس</h2>
+        <p>پرسش‌های مربوط به این سیاست را می‌توانید به
+        <a href="mailto:bb@cocode.dk">bb@cocode.dk</a> (CoCode.dk، توسعه‌دهنده: بابک بندپی) ارسال کنید.</p>
+      </section>
+
+    </div>
+    <footer>© 2026 CoCode.dk — Babak Bandpey</footer>
+  </div>
+</body>
+</html>

--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,49 @@
+# Privacy Policy — Persian Pro Calendar
+
+**App:** Persian Pro Calendar (`com.cocode.calendar`)
+**Developer:** CoCode.dk — Babak Bandpey
+**Last updated:** 14 July 2026
+
+> The canonical, always-current version of this policy is published at
+> **https://cocodedk.github.io/persian-calendar/privacy.html**
+
+**Persian Pro Calendar does not collect, transmit, or share any personal data.**
+It is a Gregorian and Persian (Jalali) calendar that works entirely on your device.
+
+## Data you create
+
+Any calendar events you add — their title, description, dates, and colour — are stored only in a
+private database on your own device. This information is never sent to us or to any third party. It
+stays on your phone and is removed if you delete the app or clear its data.
+
+## No internet, no tracking
+
+- The app requests **no internet permission**, so it is technically unable to send your data anywhere.
+- We use **no analytics, no crash reporting, and no advertising**.
+- There are **no third-party SDKs, no cookies, and no advertising identifiers**.
+- The app requests **no runtime permissions** (no location, contacts, camera, or storage access).
+
+## Device backup
+
+If you have enabled Android Auto Backup or Google account backup on your device, the operating system
+may include this app's local data in your own personal Google backup. This is controlled entirely by
+you and Google — we have no access to it. See
+[Google's Privacy Policy](https://policies.google.com/privacy) for details.
+
+## External links
+
+The app contains links to the developer's website ([cocode.dk](https://cocode.dk)) and LinkedIn
+profile. Selecting them opens your browser; those sites are governed by their own privacy policies.
+
+## Children
+
+The app does not knowingly collect data from anyone, including children.
+
+## Changes
+
+If this policy changes, the updated version will be posted here and on the website with a new
+"last updated" date.
+
+## Contact
+
+Questions about this policy can be sent to **bb@cocode.dk** (CoCode.dk, developer: Babak Bandpey).


### PR DESCRIPTION
## Why

Google Play flagged **Persian Pro Calendar** (`com.cocode.calendar`): the privacy-policy URL configured in Play Console (`github.com/cocodedk/persian-calendar/blob/main/privacy.md`) returned **HTTP 404** because no `privacy.md` existed in the repo. Deadline to fix: **11 Aug 2026**.

## What

The app collects no user data — verified from source: **no `INTERNET` permission**, no analytics/ads/Firebase/third-party SDKs, events stored only in a local Room database. So the policy honestly states everything stays on-device.

| Change | Purpose |
|--------|---------|
| `docs/privacy.html` (new) | Bilingual EN + FA (RTL) page, matches site theme → deploys to `https://cocodedk.github.io/persian-calendar/privacy.html` (new Play Console URL) |
| `privacy.md` (new) | Same policy at repo root so the previously-configured blob URL also resolves |
| `docs/index.html` | Footer now links the policy |

## Verified
- HTML well-formed; full English policy present in raw HTML (crawler-readable without JS)
- Rendered in a browser — theme + Persian RTL correct

## After merge
1. Pages auto-deploys `privacy.html` (workflow triggers on `docs/**`)
2. In Play Console: App content → Privacy policy → set URL to the Pages URL → Save → send for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a standalone privacy policy page in English and Persian.
  * Documented local-only event storage, data practices, permissions, backups, external links, children’s privacy, policy updates, and contact information.
  * Added a footer link to the new privacy policy page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->