### PR TITLE
fix(ci): select a single apksigner in release verify step

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -65,7 +65,8 @@ jobs:
       - name: Verify the APK is signed
         run: |
           APK=$(ls app/build/outputs/apk/release/*.apk | head -1)
-          "$ANDROID_HOME"/build-tools/*/apksigner verify --print-certs "$APK"
+          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort -V | tail -1)
+          "$APKSIGNER" verify --print-certs "$APK"
           cp "$APK" persian-calendar.apk
 
       - uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v2


### PR DESCRIPTION
Follow-up to #42. The `Verify the APK is signed` step used `build-tools/*/apksigner`, which globbed to **multiple** installed build-tools versions on the runner — so `apksigner` got another apksigner path as its "command" (`Unsupported command: .../35.0.0/apksigner`) and the step failed *after* a successful signed build, blocking the release publish.

Fix: pick the highest build-tools `apksigner` explicitly (`find … | sort -V | tail -1`).

No v1.3.0 tag/release was created by the failed run (it failed before the publish step). After merge I'll trigger the release via `workflow_dispatch` (version.txt is already 1.3.0 on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)